### PR TITLE
Add badges for Jest tests and linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Jest Tests](https://github.com/TDW-2025/daniel-madureira/actions/workflows/tests.yml/badge.svg)](https://github.com/TDW-2025/daniel-madureira/actions/workflows/tests.yml)
+[![Linter](https://github.com/TDW-2025/daniel-madureira/actions/workflows/linter.yml/badge.svg)](https://github.com/TDW-2025/daniel-madureira/actions/workflows/linter.yml)
+
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/pages/api-reference/create-next-app).
 
 ## Getting Started


### PR DESCRIPTION
This pull request adds status badges to the top of the `README.md` file to display the current status of the project's Jest tests and linter workflows. These badges provide quick visual feedback on the health of the codebase.