### PR TITLE
Add missing pnpm installation step in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
               with:
                   version: 10
 
+            - name: Install pnpm
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 10
+
             - name: Install dependencies
               run: pnpm install
 


### PR DESCRIPTION
This pull request updates the build workflow to ensure that `pnpm` is properly installed before running dependency installation. This change adds an explicit step to set up `pnpm` using the official GitHub Action.

* Build workflow improvements:
  * [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R27-R31): Added a step to install `pnpm` via the `pnpm/action-setup@v2` GitHub Action to guarantee the correct version is available before installing dependencies.