### PR TITLE
Fixed actoin secrets

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,7 +89,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Deploy to Netlify
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        run: pnpm netlify deploy --site=$NETLIFY_SITE_ID --auth=$NETLIFY_AUTH_TOKEN --prod
+        run: pnpm netlify deploy --site=${{ secrets.NETLIFY_SITE_ID }} --auth=${{ secrets.NETLIFY_AUTH_TOKEN }} --prod


### PR DESCRIPTION
This pull request makes a minor update to the Netlify deployment step in the GitHub Actions workflow. The change simplifies the way secrets are passed to the deployment command by using direct variable interpolation in the `run` line, rather than setting them in the `env` section.

([.github/workflows/pipeline.ymlL92-R92](diffhunk://#diff-fe700949ba86403864aa7b6fdcab2c00c55e1047f73a6a282135a35e8a21e03bL92-R92))